### PR TITLE
Remove reference to non-existant maven repository

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -18,13 +18,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>google-api-services</id>
-            <url>http://google-api-client-libraries.appspot.com/mavenrepo</url>
-        </repository>
-    </repositories>
-
     <dependencies>
 
         <!-- YouTube Data V3 support -->


### PR DESCRIPTION
There is no repository at http://google-api-client-libraries.appspot.com/mavenrepo.  These libraries can be found at sonotype.
