### PR TITLE
developer key should be added before making the second request

### DIFF
--- a/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/GeolocationSearch.java
+++ b/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/GeolocationSearch.java
@@ -140,6 +140,10 @@ public class GeolocationSearch {
                 // Call the YouTube Data API's youtube.videos.list method to
                 // retrieve the resources that represent the specified videos.
                 YouTube.Videos.List listVideosRequest = youtube.videos().list("snippet, recordingDetails").setId(videoId);
+
+                // Set your developer key
+                listVideosRequest.setKey(apiKey);
+
                 VideoListResponse listResponse = listVideosRequest.execute();
 
                 List<Video> videoList = listResponse.getItems();


### PR DESCRIPTION
I was getting following error without it.

There was a service error: 403 : Daily Limit for Unauthenticated Use Exceeded. Continued use requires signup.