### PR TITLE
Set Faraday.default_adapter to excon

### DIFF
--- a/ruby/upload_video.rb
+++ b/ruby/upload_video.rb
@@ -9,7 +9,7 @@ require 'google/api_client/auth/installed_app'
 gem 'trollop', '~> 2.1.2'
 require 'trollop'
 gem 'httpclient', '~> 2.6.0'
-Faraday.default_adapter = :httpclient
+Faraday.default_adapter = :excon
 
 # A limited OAuth 2 access scope that allows for uploading files, but not other
 # types of account access.

--- a/ruby/upload_video.rb
+++ b/ruby/upload_video.rb
@@ -6,7 +6,10 @@ require 'google/api_client'
 require 'google/api_client/client_secrets'
 require 'google/api_client/auth/file_storage'
 require 'google/api_client/auth/installed_app'
+gem 'trollop', '~> 2.1.2'
 require 'trollop'
+gem 'httpclient', '~> 2.6.0'
+Faraday.default_adapter = :httpclient
 
 # A limited OAuth 2 access scope that allows for uploading files, but not other
 # types of account access.


### PR DESCRIPTION
google-api-client uses faraday gem which default http adapter is Net::HTTP, which is not working properly. See http://stackoverflow.com/questions/24201842/uploading-a-video-to-youtube-using-youtube-data-api-broken-pipe-errnoepipe

Stack trace of the error this fixes:
https://gist.github.com/landonwilkins/bc2d04d05f7033953bac
