### PR TITLE
Typo

### DIFF
--- a/go/README
+++ b/go/README
@@ -13,7 +13,7 @@ https://code.google.com/apis/console.
 
 Example usage:
 
-   go run search_key_keyword.go
+   go run search_by_keyword.go
 
 The Freebase API and YouTube Data APIs must be enabled for the project associated with this
 key.


### PR DESCRIPTION
Typo: search_key_keyword.go -> search_by_keyword.go
