### PR TITLE
Fix sample urls on all the language projects Read Me's

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -1,12 +1,12 @@
 ## Samples in this directory:
 
-### [Create a playlist](/youtube/api-samples/blob/master/dotnet/PlaylistUpdates.cs)
+### [Create a playlist](/dotnet/PlaylistUpdates.cs)
 
 Method: youtube.playlists.insert<br>
 Description: The following code sample calls the API's <code>playlists.insert</code> method to create a private playlist
 owned by the channel authorizing the request.
 
-### [Retrieve my uploads](/youtube/api-samples/blob/master/dotnet/MyUploads.cs)
+### [Retrieve my uploads](/dotnet/MyUploads.cs)
 
 Method: youtube.playlistItems.list<br>
 Description: The following code sample calls the API's <code>playlistItems.list</code> method to retrieve a list of videos
@@ -14,13 +14,13 @@ uploaded to the channel associated with the request. The code also calls the <co
 <code>mine</code> parameter set to <code>true</code> to retrieve the playlist ID that identifies the channel's uploaded
 videos.
 
-### [Search by keyword](/youtube/api-samples/blob/master/dotnet/Search.cs)
+### [Search by keyword](/dotnet/Search.cs)
 
 Method: youtube.search.list<br>
 Description: The following code sample calls the API's <code>search.list</code> method to retrieve search results
 associated with a particular keyword.
 
-### [Upload a video](/youtube/api-samples/blob/master/dotnet/UploadVideo.cs)
+### [Upload a video](/dotnet/UploadVideo.cs)
 
 Method: youtube.videos.insert<br>
 Description: The following code sample calls the API's <code>videos.insert</code> method to upload a video to the channel

--- a/go/README.md
+++ b/go/README.md
@@ -36,19 +36,19 @@ More information about the YouTube APIs can be found at https://developer.google
 
 ## Samples in this directory:
 
-### [Authorize a request](/youtube/api-samples/blob/master/go/oauth.go)
+### [Authorize a request](/go/oauth.go)
 
 Description: This code sample performs OAuth 2.0 authorization by checking for the presence of a local file that
 contains authorization credentials. If the file is not present, the script opens a browser and waits for a response,
 then saves the returned credentials locally.
 
-### [Post a channel bulletin](/youtube/api-samples/blob/master/go/post_bulletin.go)
+### [Post a channel bulletin](/go/post_bulletin.go)
 
 Method: youtube.activities.insert<br>
 Description: This code sample calls the API's <code>activities.insert</code> method to post a bulletin to the
 channel associated with the request.
 
-### [Retrieve my uploads](/youtube/api-samples/blob/master/go/my_uploads.go)
+### [Retrieve my uploads](/go/my_uploads.go)
 
 Method: youtube.playlistItems.list<br>
 Description: This code sample calls the API's <code>playlistItems.list</code> method to retrieve a list of 
@@ -56,13 +56,13 @@ videos uploaded to the channel associated with the request. The code also calls 
 method with the <code>mine</code> parameter set to <code>true</code> to retrieve the playlist ID that identifies 
 the channel's uploaded videos.
 
-### [Search by keyword](/youtube/api-samples/blob/master/go/search_by_keyword.go)
+### [Search by keyword](/go/search_by_keyword.go)
 
 Method: youtube.search.list<br>
 Description: This code sample calls the API's <code>search.list</code> method to retrieve search results associated
 with a particular keyword.
 
-### [Upload a video](/youtube/api-samples/blob/master/go/upload_video.go)
+### [Upload a video](/go/upload_video.go)
 
 Method: youtube.videos.insert<br>
 Description: This code sample calls the API's <code>videos.insert</code> method to upload a video to the channel

--- a/java/README.md
+++ b/java/README.md
@@ -22,29 +22,29 @@ YouTube API samples, see this video:
 
 ## Samples in this directory:
 
-### [Authorize a request](/youtube/api-samples/blob/master/java/src/main/java/com/google/api/services/samples/youtube/cmdline/Auth.java)
+### [Authorize a request](/java/src/main/java/com/google/api/services/samples/youtube/cmdline/Auth.java)
 
 Description: This sample demonstrates how to use OAuth 2.0 to authorize an application to access resources on a user's behalf. 
 
-### [Add a channel subscription](/youtube/api-samples/blob/master/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/AddSubscription.java)
+### [Add a channel subscription](/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/AddSubscription.java)
 
 Method: youtube.subscriptions.insert<br>
 Description: This sample calls the API's <code>subscriptions.insert</code> method to add a subscription to a specified
 channel.
 
-### [Add a featured video](/youtube/api-samples/blob/master/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/InvideoProgramming.java)
+### [Add a featured video](/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/InvideoProgramming.java)
 
 Method: youtube.channels.update<br>
 Description: This sample calls the API's <code>channels.update</code> method to set <code>invideoPromotion</code>
 properties for the channel.
 
-### [Create a playlist](/youtube/api-samples/blob/master/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/PlaylistUpdates.java)
+### [Create a playlist](/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/PlaylistUpdates.java)
 
 Method: youtube.playlists.insert<br>
 Description: This sample calls the API's <code>playlists.insert</code> method to create a private playlist owned by the
 channel authorizing the request.
 
-### [Create and manage comments](/youtube/api-samples/blob/master/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/CommentHandling.java)
+### [Create and manage comments](/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/CommentHandling.java)
 
 Method: youtube.commentThreads.list, youtube.comments.insert, youtube.comments.list, youtube.comments.update,
 youtube.comments.setModerationStatus, youtube.comments.markAsSpam, youtube.comments.delete<br>
@@ -61,7 +61,7 @@ thread.</li>
 <code>comments.markAsSpam</code> method to mark the comment as spam, and the <code>comments.delete</code> method to
 delete the comment, using the <code>id</code> parameter to identify the comment.</li></ul>
 
-### [Create and manage comment threads](/youtube/api-samples/blob/master/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/CommentThreads.java)
+### [Create and manage comment threads](/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/CommentThreads.java)
 
 Method: youtube.commentThreads.insert, youtube.commentThreads.list, youtube.commentThreads.update<br>
 Description: This sample demonstrates how to use the following API methods to create and manage top-level comments:<br>
@@ -74,7 +74,7 @@ channel comments and once with the <code>videoId</code> parameter to retrieve vi
 channel comment. In each case, the request body contains the <code>comment</code> resource being updated.</li>
 </ul>
 
-### [Create and manage YouTube video caption tracks](/youtube/api-samples/blob/master/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/Captions.java)
+### [Create and manage YouTube video caption tracks](/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/Captions.java)
 
 Method: youtube.captions.insert, youtube.captions.list, youtube.captions.update, youtube.captions.download,
 youtube.captions.delete<br>
@@ -91,13 +91,13 @@ tracks.</li>
 identify the caption track.</li>
 </ul>
 
-### [Post a channel bulletin](/youtube/api-samples/blob/master/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/ChannelBulletin.java)
+### [Post a channel bulletin](/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/ChannelBulletin.java)
 
 Method: youtube.activities.insert<br>
 Description: This sample calls the API's <code>activities.insert</code> method to post a bulletin to the channel
 associated with the request.
 
-### [Retrieve my uploads](/youtube/api-samples/blob/master/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/MyUploads.java)
+### [Retrieve my uploads](/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/MyUploads.java)
 
 Method: youtube.playlistItems.list<br>
 Description: This sample calls the API's <code>playlistItems.list</code> method to retrieve a list of videos uploaded
@@ -105,13 +105,13 @@ to the channel associated with the request. The code also calls the <code>channe
 <code>mine</code> parameter set to <code>true</code> to retrieve the playlist ID that identifies the channel's uploaded
 videos.
 
-### [Search by keyword](/youtube/api-samples/blob/master/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/Search.java)
+### [Search by keyword](/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/Search.java)
 
 Method: youtube.search.list<br>
 Description: This sample calls the API's <code>search.list</code> method to retrieve search results associated with
 a particular keyword.
 
-### [Search by location](/youtube/api-samples/blob/master/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/GeolocationSearch.java)
+### [Search by location](/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/GeolocationSearch.java)
 
 Method: youtube.search.list, youtube.videos.list<br>
 Description: This sample calls the API's <code>search.list</code> method with the <code>type</code>, <code>q</code>, <code>location</code>, and
@@ -119,7 +119,7 @@ Description: This sample calls the API's <code>search.list</code> method with th
 at a particular location. Using the video IDs from the search result, the sample calls the API's <code>videos.list</code>
 method to retrieve location details of each video.
 
-### [Set and retrieve localized channel metadata](/youtube/api-samples/blob/master/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/ChannelLocalizations.java)
+### [Set and retrieve localized channel metadata](/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/ChannelLocalizations.java)
 
 Method: youtube.channels.update, youtube.channels.list<br>
 Description: This sample demonstrates how to use the following API methods to set and retrieve localized metadata for a
@@ -134,7 +134,7 @@ retrieve localized metadata in that language.</li>
 parameter value to retrieve all of the localized metadata for that channel.</li>
 </ul>
 
-### [Set and retrieve localized channel section metadata](/youtube/api-samples/blob/master/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/ChannelSectionLocalizations.java)
+### [Set and retrieve localized channel section metadata](/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/ChannelSectionLocalizations.java)
 
 Method: youtube.channelSections.update, youtube.channelSections.list<br>
 Description: This sample demonstrates how to use the following API methods to set and retrieve localized metadata for a
@@ -148,7 +148,7 @@ to retrieve localized metadata in that language.</li>
 <code>part</code> parameter value to retrieve all of the localized metadata for that channel section.</li>
 </ul>
 
-### [Set and retrieve localized playlist metadata](/youtube/api-samples/blob/master/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/PlaylistLocalizations.java)
+### [Set and retrieve localized playlist metadata](/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/PlaylistLocalizations.java)
 
 Method: youtube.playlists.update, youtube.playlists.list<br>
 Description: This sample demonstrates how to use the following API methods to set and retrieve localized metadata for a
@@ -162,7 +162,7 @@ retrieve localized metadata in that language.</li>
 parameter value to retrieve all of the localized metadata for that playlist.</li>
 </ul>
 
-### [Set and retrieve localized video metadata](/youtube/api-samples/blob/master/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/VideoLocalizations.java)
+### [Set and retrieve localized video metadata](/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/VideoLocalizations.java)
 
 Method: youtube.videos.update, youtube.videos.list<br>
 Description: This sample demonstrates how to use the following API methods to set and retrieve localized metadata
@@ -176,25 +176,25 @@ retrieve localized metadata in that language.</li>
 parameter value to retrieve all of the localized metadata for that video.</li>
 </ul>
 
-### [Update a video](/youtube/api-samples/blob/master/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/UpdateVideo.java)
+### [Update a video](/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/UpdateVideo.java)
 
 Method: youtube.videos.update<br>
 Description: This sample calls the API's <code>videos.update</code> method to update a video owned by the channel
 authorizing the request.
 
-### [Upload a custom video thumbnail image](/youtube/api-samples/blob/master/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/UploadThumbnail.java)
+### [Upload a custom video thumbnail image](/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/UploadThumbnail.java)
 
 Method: youtube.thumbnails.set<br>
 Description: This sample calls the API's <code>thumbnails.set</code> method to upload an image and set it as the
 thumbnail image for a video. The request must be authorized by the channel that owns the video.
 
-### [Upload a video](/youtube/api-samples/blob/master/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/UploadVideo.java)
+### [Upload a video](/java/src/main/java/com/google/api/services/samples/youtube/cmdline/data/UploadVideo.java)
 
 Method: youtube.videos.insert<br>
 Description: This sample calls the API's <code>videos.insert</code> method to upload a video to the channel associated
 with the request.
 
-### [Retrieve top 10 videos by viewcount](/youtube/api-samples/blob/master/java/src/main/java/com/google/api/services/samples/youtube/cmdline/analytics/YouTubeAnalyticsReports.java)
+### [Retrieve top 10 videos by viewcount](/java/src/main/java/com/google/api/services/samples/youtube/cmdline/analytics/YouTubeAnalyticsReports.java)
 
 Method: youtubeAnalytics.reports.query<br>
 Description: This sample calls the API's <code>reports.query</code> method to retrieve YouTube Analytics data.
@@ -202,14 +202,14 @@ By default, the report retrieves the top 10 videos based on viewcounts, and it r
 videos, sorting the results in reverse order by viewcount. By setting command line parameters, you can use the
 same code to retrieve other reports as well.
 
-### [Create a reporting job](/youtube/api-samples/blob/master/java/src/main/java/com/google/api/services/samples/youtube/cmdline/reporting/CreateReportingJob.java)
+### [Create a reporting job](/java/src/main/java/com/google/api/services/samples/youtube/cmdline/reporting/CreateReportingJob.java)
 
 Method: youtubeReporting.reportTypes.list, youtubeReporting.jobs.create<br>
 Description: This sample demonstrates how to create a reporting job. It calls the <code>reportTypes.list</code> method
 to retrieve a list of available report types. It then calls the <code>jobs.create</code> method to create a new reporting
 job.
 
-### [Retrieve reports](/youtube/api-samples/blob/master/java/src/main/java/com/google/api/services/samples/youtube/cmdline/reporting/RetrieveReports.java)
+### [Retrieve reports](/java/src/main/java/com/google/api/services/samples/youtube/cmdline/reporting/RetrieveReports.java)
 
 Method: youtubeReporting.jobs.list, youtubeReporting.reports.list<br>
 Description: This sample demonstrates how to retrieve reports created by a specific job. It calls the
@@ -217,21 +217,21 @@ Description: This sample demonstrates how to retrieve reports created by a speci
 <code>jobId</code> parameter set to a specific job id to retrieve reports created by that job. Finally, the sample
 prints out the download URL for each report.
 
-### [Create a broadcast and stream](/youtube/api-samples/blob/master/java/src/main/java/com/google/api/services/samples/youtube/cmdline/live/CreateBroadcast.java)
+### [Create a broadcast and stream](/java/src/main/java/com/google/api/services/samples/youtube/cmdline/live/CreateBroadcast.java)
 
 Method: youtube.liveBroadcasts.bind,youtube.liveBroadcasts.insert,youtube.liveStreams.insert<br>
 Description: This sample calls the API's <code>liveBroadcasts.insert</code> and <code>liveStreams.insert</code>
 methods to create a broadcast and a stream. Then, it calls the <code>liveBroadcasts.bind</code> method to bind
 the stream to the broadcast.
 
-### [Retrieve a channel's broadcasts](/youtube/api-samples/blob/master/java/src/main/java/com/google/api/services/samples/youtube/cmdline/live/ListBroadcasts.java)
+### [Retrieve a channel's broadcasts](/java/src/main/java/com/google/api/services/samples/youtube/cmdline/live/ListBroadcasts.java)
 
 Method: youtube.liveBroadcasts.list<br>
 Description: This sample calls the API's <code>liveBroadcasts.list</code> method to retrieve a list of broadcasts for
 the channel associated with the request. By default, the request retrieves all broadcasts for the channel, but you can
 also specify a value for the <code>--broadcast-status</code> option to only retrieve broadcasts with a particular status.
 
-### [Retrieve a channel's live video streams](/youtube/api-samples/blob/master/java/src/main/java/com/google/api/services/samples/youtube/cmdline/live/ListStreams.java)
+### [Retrieve a channel's live video streams](/java/src/main/java/com/google/api/services/samples/youtube/cmdline/live/ListStreams.java)
 
 Method: youtube.liveStreams.list<br>
 Description: This sample calls the API's <code>liveStreams.list</code> method to retrieve a list of video stream settings

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -1,6 +1,6 @@
 ## Samples in this directory:
 
-### [Authorize a request](/youtube/api-samples/blob/master/javascript/auth.js)
+### [Authorize a request](/javascript/auth.js)
 
 Description: The <code>auth.js</code> script demonstrates how to use the Google APIs Client Library for JavaScript
 to provide API access and authorize user requests. All of the subsequent samples on this page use this script to
@@ -11,18 +11,18 @@ For requests that do not require authentication, you could also use the
 client ID by registering your application in the
 <a href="https://console.developers.google.com">Google Developers Console</a>.
 
-### [Do resumable uploads with CORS](/youtube/api-samples/blob/master/javascript/cors_upload.js)
+### [Do resumable uploads with CORS](/javascript/cors_upload.js)
 
 Method: youtube.videos.insert
 Description: This code sample demonstrates how to execute a resumable upload using XHR/CORS.
 
-### [Create a playlist](/youtube/api-samples/blob/master/javascript/playlist_updates.js)
+### [Create a playlist](/javascript/playlist_updates.js)
 
 Method: youtube.playlists.insert<br>
 Description: This JavaScript code creates a private playlist and adds videos to that playlist. (You could, of course, modify the code so that it creates a publicly visible playlist or so that it checks a form value to determine whether the playlist is
 public or private.) Note that you need to update the client ID in the <code>auth.js</code> file to run this code.<br><br>The HTML page uses JQuery, along with the <code>auth.js</code> and <code>playlist_updates.js</code> JavaScript files, to display a simple form for adding videos to the playlist.
 
-### [Retrieve my uploads](/youtube/api-samples/blob/master/javascript/my_uploads.js)
+### [Retrieve my uploads](/javascript/my_uploads.js)
 
 Method: youtube.playlistItems.list<br>
 Description: The JavaScript sample code performs the following functions:<br>
@@ -35,13 +35,13 @@ Description: The JavaScript sample code performs the following functions:<br>
 
 The HTML page uses JQuery, the <code>auth.js</code> and <code>my_uploads.js</code> JavaScript files, and a CSS file to display the list of uploaded videos.
 
-### [Search by keyword](/youtube/api-samples/blob/master/javascript/search.js)
+### [Search by keyword](/javascript/search.js)
 
 Method: youtube.search.list<br>
 Description: This code sample calls the API's <code>search.list</code> method to retrieve search results associated
 with a particular keyword. The HTML page uses JQuery, along with the <code>auth.js</code> and <code>search.js</code> JavaScript files, to show a simple search form and display the list of search results.
 
-### [Upload a video](/youtube/api-samples/blob/master/javascript/upload_video.js)
+### [Upload a video](/javascript/upload_video.js)
 
 Method: youtube.videos.insert<br>
 Description: This JavaScript sample performs the following functions:<br>
@@ -57,7 +57,7 @@ with your project's client ID. The only valid JavaScript origin for the client I
 <code>http://localhost</code>. This means that you could test the sample locally, but it would not work in your
 production application.
 
-### [Calling the Analytics API](/youtube/api-samples/blob/master/javascript/analytics_codelab.js)
+### [Calling the Analytics API](/javascript/analytics_codelab.js)
 
 Method: youtubeAnalytics.reports.query<br>
 Description: This sample uses the YouTube Data and YouTube Analytics APIs to retrieve YouTube channel metrics.

--- a/php/README.md
+++ b/php/README.md
@@ -1,6 +1,6 @@
 ## Samples in this directory:
 
-### [Add a channel section](/youtube/api-samples/blob/master/php/add_channel_section.php)
+### [Add a channel section](/php/add_channel_section.php)
 
 Method: youtube.channelSections.insert<br>
 Description: This sample calls the API's <code>channelSections.insert</code> method to create channel sections.
@@ -12,19 +12,19 @@ property so that the channel displays content in a browse view (rather than a fe
 visible if the channel displays content in a browse view.<br><br>More information on channel sections is available in the
 <a href="https://support.google.com/youtube/answer/3027787">YouTube Help Center</a>.
 
-### [Add a channel subscription](/youtube/api-samples/blob/master/php/add_subscription.php)
+### [Add a channel subscription](/php/add_subscription.php)
 
 Method: youtube.subscriptions.insert<br>
 Description: This sample calls the API's <code>subscriptions.insert</code> method to add a subscription to a specified
 channel.
 
-### [Create a playlist](/youtube/api-samples/blob/master/php/playlist_updates.php)
+### [Create a playlist](/php/playlist_updates.php)
 
 Method: youtube.playlists.insert<br>
 Description: This sample calls the API's <code>playlists.insert</code> method to create a private playlist owned by the
 channel authorizing the request.
 
-### [Create and manage comments](/youtube/api-samples/blob/master/php/comment_handling.php)
+### [Create and manage comments](/php/comment_handling.php)
 
 Method: youtube.commentThreads.list, youtube.comments.insert, youtube.comments.list, youtube.comments.update,
 youtube.comments.setModerationStatus, youtube.comments.markAsSpam, youtube.comments.delete<br>
@@ -42,7 +42,7 @@ thread.</li>
 delete the comment, using the <code>id</code> parameter to identify the comment.</li>
 </ul>
 
-### [Create and manage comment threads](/youtube/api-samples/blob/master/php/comment_threads.php)
+### [Create and manage comment threads](/php/comment_threads.php)
 
 Method: youtube.commentThreads.insert, youtube.commentThreads.list, youtube.commentThreads.update<br>
 Description: This sample demonstrates how to use the following API methods to create and manage top-level comments:<br>
@@ -55,7 +55,7 @@ channel comments and once with the <code>videoId</code> parameter to retrieve vi
 channel comment. In each case, the request body contains the <code>comment</code> resource being updated.</li>
 </ul>
 
-### [Create and manage YouTube video caption tracks](/youtube/api-samples/blob/master/php/captions.php)
+### [Create and manage YouTube video caption tracks](/php/captions.php)
 
 Method: youtube.captions.insert, youtube.captions.list, youtube.captions.update, youtube.captions.download,
 youtube.captions.delete<br>
@@ -72,7 +72,7 @@ tracks.</li>
 identify the caption track.</li>
 </ul>
 
-### [Retrieve my uploads](/youtube/api-samples/blob/master/php/my_uploads.php)
+### [Retrieve my uploads](/php/my_uploads.php)
 
 Method: youtube.playlistItems.list<br>
 Description: This sample calls the API's <code>playlistItems.list</code> method to retrieve a list of videos uploaded
@@ -80,13 +80,13 @@ to the channel associated with the request. The code also calls the <code>channe
 <code>mine</code> parameter set to <code>true</code> to retrieve the playlist ID that identifies the channel's uploaded
 videos.
 
-### [Search by keyword](/youtube/api-samples/blob/master/php/search.php)
+### [Search by keyword](/php/search.php)
 
 Method: youtube.search.list<br>
 Description: This sample calls the API's <code>search.list</code> method to retrieve search results associated with
 a particular keyword.
 
-### [Search by location](/youtube/api-samples/blob/master/php/geolocation_search.php)
+### [Search by location](/php/geolocation_search.php)
 
 Method: youtube.search.list, youtube.videos.list<br>
 Description: This sample calls the API's <code>search.list</code> method with the <code>type</code>, <code>q</code>,
@@ -94,7 +94,7 @@ Description: This sample calls the API's <code>search.list</code> method with th
 keyword within the radius centered at a particular location. Using the video IDs from the search result, the sample
 calls the API's <code>videos.list</code> method to retrieve location details of each video.
 
-### [Set and retrieve localized channel metadata](/youtube/api-samples/blob/master/php/channel_localizations.php)
+### [Set and retrieve localized channel metadata](/php/channel_localizations.php)
 
 Method: youtube.channels.update, youtube.channels.list<br>
 Description: This sample demonstrates how to use the following API methods to set and retrieve localized metadata for a
@@ -109,7 +109,7 @@ retrieve localized metadata in that language.</li>
 parameter value to retrieve all of the localized metadata for that channel.</li>
 </ul>
 
-### [Set and retrieve localized channel section metadata](/youtube/api-samples/blob/master/php/channel_section_localizations.php)
+### [Set and retrieve localized channel section metadata](/php/channel_section_localizations.php)
 
 Method: youtube.channelSections.update, youtube.channelSections.list<br>
 Description: This sample demonstrates how to use the following API methods to set and retrieve localized metadata for a
@@ -123,7 +123,7 @@ to retrieve localized metadata in that language.</li>
 <code>part</code> parameter value to retrieve all of the localized metadata for that channel section.</li>
 </ul>
 
-### [Set and retrieve localized playlist metadata](/youtube/api-samples/blob/master/php/playlist_localizations.php)
+### [Set and retrieve localized playlist metadata](/php/playlist_localizations.php)
 
 Method: youtube.playlists.update, youtube.playlists.list<br>
 Description: This sample demonstrates how to use the following API methods to set and retrieve localized metadata for a
@@ -137,7 +137,7 @@ retrieve localized metadata in that language.</li>
 parameter value to retrieve all of the localized metadata for that playlist.</li>
 </ul>
 
-### [Set and retrieve localized video metadata](/youtube/api-samples/blob/master/php/video_localizations.php)
+### [Set and retrieve localized video metadata](/php/video_localizations.php)
 
 Method: youtube.videos.update, youtube.videos.list<br>
 Description: This sample demonstrates how to use the following API methods to set and retrieve localized metadata
@@ -151,7 +151,7 @@ retrieve localized metadata in that language.</li>
 parameter value to retrieve all of the localized metadata for that video.</li>
 </ul>
 
-### [Shuffle existing channel sections](/youtube/api-samples/blob/master/php/shuffle_channel_sections.php)
+### [Shuffle existing channel sections](/php/shuffle_channel_sections.php)
 
 Method: youtube.channelSections.list,youtube.channelSections.update<br>
 Description: This sample calls the API's <code>channelSections.list</code> method to get the list of current channel
@@ -159,7 +159,7 @@ sections, shuffles them, and then calls <code>channelSections.update</code> to c
 More information on channel sections is available in the
 <a href="https://support.google.com/youtube/answer/3027787">YouTube Help Center</a>.
 
-### [Update a video](/youtube/api-samples/blob/master/php/update_video.php)
+### [Update a video](/php/update_video.php)
 
 Method: youtube.videos.update<br>
 Description: This code sample demonstrates how to add tags into an existing video.<br><br>The following code
@@ -168,13 +168,13 @@ to get the video object. Using this video object, the sample gets the list of ta
 end of this list.  Finally, the code calls <code>youtube.videos.update</code> method with updated video object
 to persist these changes on YouTube.
 
-### [Upload a banner image and set as channel's banner](/youtube/api-samples/blob/master/php/upload_banner.php)
+### [Upload a banner image and set as channel's banner](/php/upload_banner.php)
 
 Method: youtube.channelBanners.insert, youtube.channels.update<br>
 Description: This sample calls the API's <code>channelBanners.insert</code> method to upload an image. With the
 returned URL, the sample calls <code>channels.update</code> method to update the channel's banner to this image.
 
-### [Upload a custom video thumbnail image](/youtube/api-samples/blob/master/php/upload_thumbnail.php)
+### [Upload a custom video thumbnail image](/php/upload_thumbnail.php)
 
 Method: youtube.thumbnails.set<br>
 Description: This sample demonstrates how to upload a custom video thumbnail to YouTube and set it for a video.
@@ -184,41 +184,41 @@ ID to use a custom image as a thumbnail to the video. For the image upload, the 
 <code>true</code> to upload the image piece-by-piece, allowing for subsequent retries to resume uploading from
 a point close to where the previous retry failed, a feature useful for programs that need to upload large files.
 
-### [Upload a video](/youtube/api-samples/blob/master/php/resumable_upload.php)
+### [Upload a video](/php/resumable_upload.php)
 
 Method: youtube.videos.insert<br>
 Description: The following code sample calls the API's <code>videos.insert</code> method to add a video to user's
 channel. The code also utilizes <code>Google_MediaFileUpload</code> class with the <code>resumable upload</code>
 parameter set to <code>true</code> to be able to to upload the video in chunks.
 
-### [Create a broadcast and stream](/youtube/api-samples/blob/master/php/create_broadcast.php)
+### [Create a broadcast and stream](/php/create_broadcast.php)
 
 Method: youtube.liveBroadcasts.bind,youtube.liveBroadcasts.insert,youtube.liveStreams.insert<br>
 Description: This sample calls the API's <code>liveBroadcasts.insert</code> and <code>liveStreams.insert</code>
 methods to create a broadcast and a stream. Then, it calls the <code>liveBroadcasts.bind</code> method to bind
 the stream to the broadcast.
 
-### [Retrieve a channel's broadcasts](/youtube/api-samples/blob/master/php/list_broadcasts.php)
+### [Retrieve a channel's broadcasts](/php/list_broadcasts.php)
 
 Method: youtube.liveBroadcasts.list<br>
 Description: This sample calls the API's <code>liveBroadcasts.list</code> method to retrieve a list of broadcasts for
 the channel associated with the request. By default, the request retrieves all broadcasts for the channel, but you can
 also specify a value for the <code>--broadcast-status</code> option to only retrieve broadcasts with a particular status.
 
-### [Retrieve a channel's live video streams](/youtube/api-samples/blob/master/php/list_streams.php)
+### [Retrieve a channel's live video streams](/php/list_streams.php)
 
 Method: youtube.liveStreams.list<br>
 Description: This sample calls the API's <code>liveStreams.list</code> method to retrieve a list of video stream settings
 that a channel can use to broadcast live events on YouTube.
 
-### [Create a reporting job](/youtube/api-samples/blob/master/php/create_reporting_job.php)
+### [Create a reporting job](/php/create_reporting_job.php)
 
 Method: youtubeReporting.reportTypes.list, youtubeReporting.jobs.create<br>
 Description: This sample demonstrates how to create a reporting job. It calls the <code>reportTypes.list</code> method
 to retrieve a list of available report types. It then calls the <code>jobs.create</code> method to create a new reporting
 job.
 
-### [Retrieve reports](/youtube/api-samples/blob/master/php/retrieve_reports.php)
+### [Retrieve reports](/php/retrieve_reports.php)
 
 Method: youtubeReporting.jobs.list, youtubeReporting.reports.list<br>
 Description: This sample demonstrates how to retrieve reports created by a specific job. It calls the

--- a/python/README.md
+++ b/python/README.md
@@ -1,6 +1,6 @@
 ## Samples in this directory:
 
-### [Add a channel section](/youtube/api-samples/blob/master/python/add_channel_section.py)
+### [Add a channel section](/python/add_channel_section.py)
 
 Method: youtube.channelSections.insert<br>
 Description: This sample calls the API's <code>channelSections.insert</code> method to create channel sections.
@@ -12,25 +12,25 @@ property so that the channel displays content in a browse view (rather than a fe
 visible if the channel displays content in a browse view.<br><br>More information on channel sections is available in the
 <a href="https://support.google.com/youtube/answer/3027787">YouTube Help Center</a>.
 
-### [Add a channel subscription](/youtube/api-samples/blob/master/python/add_subscription.py)
+### [Add a channel subscription](/python/add_subscription.py)
 
 Method: youtube.subscriptions.insert<br>
 Description: This sample calls the API's <code>subscriptions.insert</code> method to add a subscription to a specified
 channel.
 
-### [Add a featured video](/youtube/api-samples/blob/master/python/add_featured_video.py)
+### [Add a featured video](/python/add_featured_video.py)
 
 Method: youtube.channels.update<br>
 Description: This sample calls the API's <code>channels.update</code> method to set <code>invideoPromotion</code>
 properties for the channel.
 
-### [Create a playlist](/youtube/api-samples/blob/master/python/playlist_updates.py)
+### [Create a playlist](/python/playlist_updates.py)
 
 Method: youtube.playlists.insert<br>
 Description: This sample calls the API's <code>playlists.insert</code> method to create a private playlist owned by the
 channel authorizing the request.
 
-### [Create and manage comments](/youtube/api-samples/blob/master/python/comment_handling.py)
+### [Create and manage comments](/python/comment_handling.py)
 
 Method: youtube.commentThreads.list, youtube.comments.insert, youtube.comments.list, youtube.comments.update,
 youtube.comments.setModerationStatus, youtube.comments.markAsSpam, youtube.comments.delete<br>
@@ -48,7 +48,7 @@ thread.</li>
 delete the comment, using the <code>id</code> parameter to identify the comment.</li>
 </ul>
 
-### [Create and manage comment threads](/youtube/api-samples/blob/master/python/comment_threads.py)
+### [Create and manage comment threads](/python/comment_threads.py)
 
 Method: youtube.commentThreads.insert, youtube.commentThreads.list, youtube.commentThreads.update<br>
 Description: This sample demonstrates how to use the following API methods to create and manage top-level comments:<br>
@@ -61,7 +61,7 @@ channel comments and once with the <code>videoId</code> parameter to retrieve vi
 channel comment. In each case, the request body contains the <code>comment</code> resource being updated.</li>
 </ul>
 
-### [Create and manage YouTube video caption tracks](/youtube/api-samples/blob/master/python/captions.py)
+### [Create and manage YouTube video caption tracks](/python/captions.py)
 
 Method: youtube.captions.insert, youtube.captions.list, youtube.captions.update, youtube.captions.download,
 youtube.captions.delete<br>
@@ -78,24 +78,24 @@ tracks.</li>
 identify the caption track.</li>
 </ul>
 
-### [Like a video](/youtube/api-samples/blob/master/python/like_video.py)
+### [Like a video](/python/like_video.py)
 
 Method: youtube.videos.rate<br>
 Description: This sample calls the API's <code>videos.rate</code> method to set a positive rating for a video.
 
-### [Post a channel bulletin](/youtube/api-samples/blob/master/python/channel_bulletin.py)
+### [Post a channel bulletin](/python/channel_bulletin.py)
 
 Method: youtube.activities.insert<br>
 Description: This sample calls the API's <code>activities.insert</code> method to post a bulletin to the channel
 associated with the request.
 
-### [Remove a watermark image from a channel](/youtube/api-samples/blob/master/python/unset_watermark.py)
+### [Remove a watermark image from a channel](/python/unset_watermark.py)
 
 Method: youtube.watermarks.unset<br>
 Description: This sample calls the API's <code>watermarks.unset</code> method to remove the watermark
 image for a channel. The request must be authorized by the channel that owns the video.
 
-### [Retrieve my uploads](/youtube/api-samples/blob/master/python/my_uploads.py)
+### [Retrieve my uploads](/python/my_uploads.py)
 
 Method: youtube.playlistItems.list<br>
 Description: This sample calls the API's <code>playlistItems.list</code> method to retrieve a list of videos uploaded
@@ -103,13 +103,13 @@ to the channel associated with the request. The code also calls the <code>channe
 <code>mine</code> parameter set to <code>true</code> to retrieve the playlist ID that identifies the channel's uploaded
 videos.
 
-### [Search by keyword](/youtube/api-samples/blob/master/python/search.py)
+### [Search by keyword](/python/search.py)
 
 Method: youtube.search.list<br>
 Description: This sample calls the API's <code>search.list</code> method to retrieve search results associated with
 a particular keyword.
 
-### [Search by location](/youtube/api-samples/blob/master/python/geolocation_search.py)
+### [Search by location](/python/geolocation_search.py)
 
 Method: youtube.search.list, youtube.videos.list<br>
 Description: This sample calls the API's <code>search.list</code> method with the <code>type</code>,
@@ -118,7 +118,7 @@ matching the provided keyword within the radius centered at a particular locatio
 the search result, the sample calls the API's <code>videos.list</code> method to retrieve location details
 of each video.
 
-### [Set and retrieve localized channel metadata](/youtube/api-samples/blob/master/python/channel_localizations.py)
+### [Set and retrieve localized channel metadata](/python/channel_localizations.py)
 
 Method: youtube.channels.update, youtube.channels.list<br>
 Description: This sample demonstrates how to use the following API methods to set and retrieve localized metadata for a
@@ -133,7 +133,7 @@ retrieve localized metadata in that language.</li>
 parameter value to retrieve all of the localized metadata for that channel.</li>
 </ul>
 
-### [Set and retrieve localized channel section metadata](/youtube/api-samples/blob/master/python/channel_section_localizations.py)
+### [Set and retrieve localized channel section metadata](/python/channel_section_localizations.py)
 
 Method: youtube.channelSections.update, youtube.channelSections.list<br>
 Description: This sample demonstrates how to use the following API methods to set and retrieve localized metadata for a
@@ -147,7 +147,7 @@ to retrieve localized metadata in that language.</li>
 <code>part</code> parameter value to retrieve all of the localized metadata for that channel section.</li>
 </ul>
 
-### [Set and retrieve localized playlist metadata](/youtube/api-samples/blob/master/python/playlist_localizations.py)
+### [Set and retrieve localized playlist metadata](/python/playlist_localizations.py)
 
 Method: youtube.playlists.update, youtube.playlists.list<br>
 Description: This sample demonstrates how to use the following API methods to set and retrieve localized metadata for a
@@ -161,7 +161,7 @@ retrieve localized metadata in that language.</li>
 parameter value to retrieve all of the localized metadata for that playlist.</li>
 </ul>
 
-### [Set and retrieve localized video metadata](/youtube/api-samples/blob/master/python/video_localizations.py)
+### [Set and retrieve localized video metadata](/python/video_localizations.py)
 
 Method: youtube.videos.update, youtube.videos.list<br>
 Description: This sample demonstrates how to use the following API methods to set and retrieve localized metadata
@@ -175,7 +175,7 @@ retrieve localized metadata in that language.</li>
 parameter value to retrieve all of the localized metadata for that video.</li>
 </ul>
 
-### [Shuffle existing channel sections](/youtube/api-samples/blob/master/python/shuffle_channel_sections.py)
+### [Shuffle existing channel sections](/python/shuffle_channel_sections.py)
 
 Method: youtube.channelSections.list,youtube.channelSections.update<br>
 Description: This sample calls the API's <code>channelSections.list</code> method to get the list of current channel
@@ -183,57 +183,57 @@ sections. Then it shuffles the list and calls <code>channelSections.update</code
 More information on channel sections is available in the
 <a href="https://support.google.com/youtube/answer/3027787">YouTube Help Center</a>.
 
-### [Update a video](/youtube/api-samples/blob/master/python/update_video.py)
+### [Update a video](/python/update_video.py)
 
 Method: youtube.videos.update<br>
 Description: This sample calls the API's <code>videos.update</code> method to update a video owned by the channel
 authorizing the request.
 
-### [Upload a banner image and set as channel's banner](/youtube/api-samples/blob/master/python/upload_banner.py)
+### [Upload a banner image and set as channel's banner](/python/upload_banner.py)
 
 Method: youtube.channelBanners.insert, youtube.channels.update<br>
 Description: This sample calls the API's <code>channelBanners.insert</code> method to upload an image. With the
 returned URL, the sample calls <code>channels.update</code> method to update the channel's banner to that image.
 
-### [Upload a video](/youtube/api-samples/blob/master/python/upload_video.py)
+### [Upload a video](/python/upload_video.py)
 
 Method: youtube.videos.insert<br>
 Description: This sample calls the API's <code>videos.insert</code> method to upload a video to the channel associated
 with the request.
 
-### [Upload a video thumbnail image](/youtube/api-samples/blob/master/python/upload_thumbnail.py)
+### [Upload a video thumbnail image](/python/upload_thumbnail.py)
 
 Method: youtube.thumbnails.set<br>
 Description: This sample calls the API's <code>thumbnails.set</code> method to upload an image and set it as the
 thumbnail image for a video. The request must be authorized by the channel that owns the video.
 
-### [Upload a watermark image and set it for a channel](/youtube/api-samples/blob/master/python/set_watermark.py)
+### [Upload a watermark image and set it for a channel](/python/set_watermark.py)
 
 Method: youtube.watermarks.set<br>
 Description: This sample calls the API's <code>watermarks.set</code> method to upload an image and set it as the
 watermark image for a channel. The request must be authorized by the channel that owns the video.
 
-### [Create a broadcast and stream](/youtube/api-samples/blob/master/python/create_broadcast.py)
+### [Create a broadcast and stream](/python/create_broadcast.py)
 
 Method: youtube.liveBroadcasts.bind,youtube.liveBroadcasts.insert,youtube.liveStreams.insert<br>
 Description: This sample calls the API's <code>liveBroadcasts.insert</code> and <code>liveStreams.insert</code>
 methods to create a broadcast and a stream. Then, it calls the <code>liveBroadcasts.bind</code> method to bind
 the stream to the broadcast.
 
-### [Retrieve a channel's broadcasts](/youtube/api-samples/blob/master/python/list_broadcasts.py)
+### [Retrieve a channel's broadcasts](/python/list_broadcasts.py)
 
 Method: youtube.liveBroadcasts.list<br>
 Description: This sample calls the API's <code>liveBroadcasts.list</code> method to retrieve a list of broadcasts for
 the channel associated with the request. By default, the request retrieves all broadcasts for the channel, but you can
 also specify a value for the <code>--broadcast-status</code> option to only retrieve broadcasts with a particular status.
 
-### [Retrieve a channel's live video streams](/youtube/api-samples/blob/master/python/list_streams.py)
+### [Retrieve a channel's live video streams](/python/list_streams.py)
 
 Method: youtube.liveStreams.list<br>
 Description: This sample calls the API's <code>liveStreams.list</code> method to retrieve a list of video stream settings
 that a channel can use to broadcast live events on YouTube.
 
-### [Retrieve top 10 videos by viewcount](/youtube/api-samples/blob/master/python/yt_analytics_report.py)
+### [Retrieve top 10 videos by viewcount](/python/yt_analytics_report.py)
 
 Method: youtubeAnalytics.reports.query<br>
 Description: This sample calls the API's <code>reports.query</code> method to retrieve YouTube Analytics data.
@@ -241,14 +241,14 @@ By default, the report retrieves the top 10 videos based on viewcounts, and it r
 videos, sorting the results in reverse order by viewcount. By setting command line parameters, you can use the
 same code to retrieve other reports as well.
 
-### [Create a reporting job](/youtube/api-samples/blob/master/python/create_reporting_job.py)
+### [Create a reporting job](/python/create_reporting_job.py)
 
 Method: youtubeReporting.reportTypes.list, youtubeReporting.jobs.create<br>
 Description: This sample demonstrates how to create a reporting job. It calls the <code>reportTypes.list</code> method
 to retrieve a list of available report types. It then calls the <code>jobs.create</code> method to create a new reporting
 job.
 
-### [Retrieve reports](/youtube/api-samples/blob/master/python/retrieve_reports.py)
+### [Retrieve reports](/python/retrieve_reports.py)
 
 Method: youtubeReporting.jobs.list, youtubeReporting.reports.list<br>
 Description: This sample demonstrates how to retrieve reports created by a specific job. It calls the

--- a/python_appengine/README.md
+++ b/python_appengine/README.md
@@ -1,13 +1,13 @@
 ## Samples in this directory:
 
-### [Retrieve a channel's uploads](/youtube/api-samples/blob/master/python_appengine/user_uploads/main.py)
+### [Retrieve a channel's uploads](/python_appengine/user_uploads/main.py)
 
 Method: youtube.playlistItems.list
 Description: This code sample calls the API's <code>playlistItems.list</code> method to retrieve a list of videos uploaded
 to a specified channel. The channel can be identified by its channel ID or channel name. The code also calls the
 <code>channels.list</code> method to retrieve the playlist ID that identifies the channel's uploaded videos.
 
-### [Search by keyword](/youtube/api-samples/blob/master/python_appengine/search/main.py)
+### [Search by keyword](/python_appengine/search/main.py)
 
 Method: youtube.search.list
 Description: This code sample calls the API's <code>search.list</code> method to retrieve search results associated

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1,24 +1,24 @@
 ## Samples in this directory:
 
-### [Authorize a request](/youtube/api-samples/blob/master/ruby/oauth/oauth_util.rb)
+### [Authorize a request](/ruby/oauth/oauth_util.rb)
 
 Description: The following code sample performs OAuth 2.0 authorization by checking for the presence of a local
 file that contains authorization credentials. If the file is not present, the script opens a browser and waits
 for a response, then saves the returned credentials locally.
 
-### [Add a channel subscription](/youtube/api-samples/blob/master/ruby/add_subscription.rb)
+### [Add a channel subscription](/ruby/add_subscription.rb)
 
 Method: youtube.subscriptions.insert<br>
 Description: This sample calls the API's <code>subscriptions.insert</code> method to add a subscription
 to a specified channel.
 
-### [Post a channel bulletin](/youtube/api-samples/blob/master/ruby/channel_bulletin.rb)
+### [Post a channel bulletin](/ruby/channel_bulletin.rb)
 
 Method: youtube.activities.insert<br>
 Description: This sample calls the API's <code>activities.insert</code> method to post a bulletin to the channel
 associated with the request.
 
-### [Retrieve my uploads](/youtube/api-samples/blob/master/ruby/my_uploads.rb)
+### [Retrieve my uploads](/ruby/my_uploads.rb)
 
 Method: youtube.playlistItems.list<br>
 Description: This sample calls the API's <code>playlistItems.list</code> method to retrieve a list of videos uploaded
@@ -26,19 +26,19 @@ to the channel associated with the request. The code also calls the <code>channe
 <code>mine</code> parameter set to <code>true</code> to retrieve the playlist ID that identifies the channel's
 uploaded videos.
 
-### [Search by keyword](/youtube/api-samples/blob/master/ruby/search.rb)
+### [Search by keyword](/ruby/search.rb)
 
 Method: youtube.search.list<br>
 Description: This sample calls the API's <code>search.list</code> method to retrieve search results
 associated with a particular keyword.
 
-### [Upload a video](/youtube/api-samples/blob/master/ruby/upload_video.rb)
+### [Upload a video](/ruby/upload_video.rb)
 
 Method: youtube.videos.insert<br>
 Description: This sample calls the API's <code>videos.insert</code> method to upload a video to the channel
 associated with the request.
 
-### [Retrieve top 10 videos by viewcount](/youtube/api-samples/blob/master/ruby/yt_analytics_report.rb)
+### [Retrieve top 10 videos by viewcount](/ruby/yt_analytics_report.rb)
 
 Method: youtubeAnalytics.reports.query<br>
 Description: This sample calls the API's <code>reports.query</code> method to retrieve YouTube Analytics data.


### PR DESCRIPTION
Some of the URLs you are using on your language ReadMe's are redirecting to a 404 page because url was being appended to twice. 

So I removed "youtube/api-samples/blob/master/" from each of the Read Me's and they seem to be all good (tested from my fork on GitHub)

Read more about it [here](https://help.github.com/articles/about-readmes/#relative-links-and-image-paths-in-readme-files)