### PR TITLE
Fix report downloading in PHP example #70

### DIFF
--- a/php/retrieve_reports.php
+++ b/php/retrieve_reports.php
@@ -167,11 +167,11 @@ function downloadReport(Google_Service_YouTubeReporting $youtubeReporting, $repo
   $client->setDefer(true);
 
   // Call the YouTube Reporting API's media.download method to download a report.
-  $request = $youtubeReporting->media->download("");
-  $request->setUrl($reportUrl);
+  $request = $youtubeReporting->media->download("", array("alt" => "media"));
+  $request = $request->withUri(new \GuzzleHttp\Psr7\Uri($reportUrl));
   $response = $client->execute($request);
 
-  file_put_contents("reportFile", $response->getResponseBody());
+  file_put_contents("reportFile", $response->getBody());
   $client->setDefer(false);
 }
 ?>


### PR DESCRIPTION
If the query parameter `alt` isn't set to `media`, then an extra header is added to the request that denotes the PHP class that should be used to handle the response. To deal with that the following line is updated:
```
$request = $youtubeReporting->media->download("", array("alt" => "media"));
```
The URL of the Guzzle Request can be changed like this:
```
$request = $request->withUri(new \GuzzleHttp\Psr7\Uri($reportUrl));
```
The method `getResponseBody` is updated with `\GuzzleHttp\Psr7\Response->getBody`:
```
file_put_contents("reportFile", $response->getBody());
```