### PR TITLE
Adjustment of Require Statement to Reflect Changes to Google-Auth-Library

### DIFF
--- a/javascript/nodejs-quickstart.js
+++ b/javascript/nodejs-quickstart.js
@@ -1,7 +1,7 @@
 var fs = require('fs');
 var readline = require('readline');
 var google = require('googleapis');
-var googleAuth = require('google-auth-library');
+var OAuth2Client = require('google-auth-library').OAuth2Client;
 
 // If modifying these scopes, delete your previously saved credentials
 // at ~/.credentials/youtube-nodejs-quickstart.json
@@ -31,8 +31,7 @@ function authorize(credentials, callback) {
   var clientSecret = credentials.installed.client_secret;
   var clientId = credentials.installed.client_id;
   var redirectUrl = credentials.installed.redirect_uris[0];
-  var auth = new googleAuth();
-  var oauth2Client = new auth.OAuth2(clientId, clientSecret, redirectUrl);
+  var oauth2Client = new OAuth2Client(clientId, clientSecret, redirectUrl);
 
   // Check if we have previously stored a token.
   fs.readFile(TOKEN_PATH, function(err, token) {


### PR DESCRIPTION
Adjusted the require statement to require the OAuth2Client module directly since googleAuth is no longer a constructor within the google-auth-library module. Removed line 34 for the same reasons. Adjust line 35 (now line 34) to create a new OAuth2Client directly