### PR TITLE
Fix go oauth2 sample openURL function used Windows

### DIFF
--- a/go/oauth2.go
+++ b/go/oauth2.go
@@ -127,7 +127,7 @@ func openURL(url string) error {
 	case "linux":
 		err = exec.Command("xdg-open", url).Start()
 	case "windows":
-		err = exec.Command("rundll32", "url.dll,FileProtocolHandler", "http://localhost:4001/").Start()
+		err = exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
 	case "darwin":
 		err = exec.Command("open", url).Start()
 	default:


### PR DESCRIPTION
exec.Command argument URL was the same URL as the reference source code