### PR TITLE
Refactor node quickstart using modern async/await

### DIFF
--- a/javascript/nodejs-quickstart.js
+++ b/javascript/nodejs-quickstart.js
@@ -1,125 +1,84 @@
-var fs = require('fs');
-var readline = require('readline');
-var {google} = require('googleapis');
-var OAuth2 = google.auth.OAuth2;
+const fs = require('fs/promises');
+const readline = require('readline');
+const {google} = require('googleapis');
+const OAuth2 = google.auth.OAuth2;
 
-// If modifying these scopes, delete your previously saved credentials
-// at ~/.credentials/youtube-nodejs-quickstart.json
-var SCOPES = ['https://www.googleapis.com/auth/youtube.readonly'];
-var TOKEN_DIR = (process.env.HOME || process.env.HOMEPATH ||
-    process.env.USERPROFILE) + '/.credentials/';
-var TOKEN_PATH = TOKEN_DIR + 'youtube-nodejs-quickstart.json';
-
-// Load client secrets from a local file.
-fs.readFile('client_secret.json', function processClientSecrets(err, content) {
-  if (err) {
-    console.log('Error loading client secret file: ' + err);
-    return;
-  }
-  // Authorize a client with the loaded credentials, then call the YouTube API.
-  authorize(JSON.parse(content), getChannel);
-});
-
-/**
- * Create an OAuth2 client with the given credentials, and then execute the
- * given callback function.
- *
- * @param {Object} credentials The authorization client credentials.
- * @param {function} callback The callback to call with the authorized client.
- */
-function authorize(credentials, callback) {
-  var clientSecret = credentials.installed.client_secret;
-  var clientId = credentials.installed.client_id;
-  var redirectUrl = credentials.installed.redirect_uris[0];
-  var oauth2Client = new OAuth2(clientId, clientSecret, redirectUrl);
-
-  // Check if we have previously stored a token.
-  fs.readFile(TOKEN_PATH, function(err, token) {
-    if (err) {
-      getNewToken(oauth2Client, callback);
-    } else {
-      oauth2Client.credentials = JSON.parse(token);
-      callback(oauth2Client);
-    }
-  });
+async function readJSON(filename) {
+    const content = await fs.readFile(filename);
+    return JSON.parse(content);
 }
 
-/**
- * Get and store new token after prompting for user authorization, and then
- * execute the given callback with the authorized OAuth2 client.
- *
- * @param {google.auth.OAuth2} oauth2Client The OAuth2 client to get token for.
- * @param {getEventsCallback} callback The callback to call with the authorized
- *     client.
- */
-function getNewToken(oauth2Client, callback) {
-  var authUrl = oauth2Client.generateAuthUrl({
-    access_type: 'offline',
-    scope: SCOPES
-  });
-  console.log('Authorize this app by visiting this url: ', authUrl);
-  var rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout
-  });
-  rl.question('Enter the code from that page here: ', function(code) {
-    rl.close();
-    oauth2Client.getToken(code, function(err, token) {
-      if (err) {
-        console.log('Error while trying to retrieve access token', err);
-        return;
-      }
-      oauth2Client.credentials = token;
-      storeToken(token);
-      callback(oauth2Client);
+async function writeJSON(filename, data) {
+    const content = JSON.stringify(data);
+    await fs.writeFile(filename, content);
+}
+
+async function oauth(oauth2Client) {
+    const authUrl = oauth2Client.generateAuthUrl({
+        access_type: 'offline',
+        scope: ['https://www.googleapis.com/auth/youtube'],
     });
-  });
+    const code = await askCode(authUrl);
+    return await oauth2Client.getToken(code);
 }
 
-/**
- * Store token to disk be used in later program executions.
- *
- * @param {Object} token The token to store to disk.
- */
-function storeToken(token) {
-  try {
-    fs.mkdirSync(TOKEN_DIR);
-  } catch (err) {
-    if (err.code != 'EEXIST') {
-      throw err;
-    }
-  }
-  fs.writeFile(TOKEN_PATH, JSON.stringify(token), (err) => {
-    if (err) throw err;
-    console.log('Token stored to ' + TOKEN_PATH);
-  });
+function askCode(authUrl) {
+    const rlp = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+        terminal: true
+    });
+
+    return new Promise((resolve, reject) => {
+        console.log('Authorize this app by visiting this url: ', authUrl);
+        const code = rlp.question('Than enter the code from that page here: ', code => {
+            rlp.close();
+            resolve(code);
+        });
+    });
 }
 
-/**
- * Lists the names and IDs of up to 10 files.
- *
- * @param {google.auth.OAuth2} auth An authorized OAuth2 client.
- */
-function getChannel(auth) {
-  var service = google.youtube('v3');
-  service.channels.list({
-    auth: auth,
-    part: 'snippet,contentDetails,statistics',
-    forUsername: 'GoogleDevelopers'
-  }, function(err, response) {
-    if (err) {
-      console.log('The API returned an error: ' + err);
-      return;
-    }
-    var channels = response.data.items;
-    if (channels.length == 0) {
-      console.log('No channel found.');
-    } else {
-      console.log('This channel\'s ID is %s. Its title is \'%s\', and ' +
-                  'it has %s views.',
-                  channels[0].id,
-                  channels[0].snippet.title,
-                  channels[0].statistics.viewCount);
-    }
-  });
+async function getAndStoreNewToken(oauth2Client, filename) {
+    const token = await oauth(oauth2Client);
+    await writeJSON(filename, token);
+    return token;
 }
+
+async function getExistingOrNewToken(oauth2Client, filename) {
+    try {
+        return await readJSON(filename);
+    } catch (err) {
+        return await getAndStoreNewToken(oauth2Client, filename);
+    }
+}
+
+async function createOAuth2ClientWithToken(credentialsFilename, tokenFilename) {
+    const credentials = await readJSON(credentialsFilename);
+    const oauth2Client = new OAuth2(
+        credentials.installed.client_id,
+        credentials.installed.client_secret,
+        credentials.installed.redirect_uris[0],
+    );
+
+    const {tokens} = await getExistingOrNewToken(oauth2Client, tokenFilename);
+    oauth2Client.setCredentials(tokens);
+
+    return oauth2Client;
+}
+
+async function getLikes() {
+    const oauth2Client = await createOAuth2ClientWithToken('client_secret.json', '.token');
+    const ytApi = google.youtube('v3');
+
+    const res = await ytApi.videos.list({
+        auth: oauth2Client,
+        part: 'id',
+        myRating: 'like',
+        maxResults: 5,
+    });
+
+    const videos = res.data.items;
+    videos.forEach(video => console.log('You liked', video.id));
+}
+
+getLike();


### PR DESCRIPTION
Today I had a look at quickstart code for using oath2 and the YouTube Data API via node js (https://developers.google.com/youtube/v3/quickstart/nodejs#step_3_set_up_the_sample). However as it was using what I refer to as "callback hell", which made it really hard to understand and even harder to change it. I ended up refactoring the entire example using javascript's async/await syntax sugar. I figured I'd share my results.