### PR TITLE
Error running example: cannot use "id,snippet" (type string) as type …

### DIFF
--- a/go/search_by_keyword.go
+++ b/go/search_by_keyword.go
@@ -30,7 +30,7 @@ func main() {
 	}
 
 	// Make the API call to YouTube.
-	call := service.Search.List("id,snippet").
+	call := service.Search.List([]string{"id,snippet"}).
 		Q(*query).
 		MaxResults(*maxResults)
 	response, err := call.Do()


### PR DESCRIPTION
…[]string in argument to service.Search.List

When running the example Search api call, I get this error: `cannot use "id,snippet" (type string) as type []string in argument to service.Search.List`. If there is a better way of converting "id,snippet" to a string slice, I'm open to suggestions as I'm newer to Go. 

❯ go version
go version go1.15.3 darwin/amd64