### PR TITLE
missing comma in parameters

### DIFF
--- a/python/yt_analytics_v2.py
+++ b/python/yt_analytics_v2.py
@@ -35,7 +35,7 @@ if __name__ == '__main__':
       ids='channel==MINE',
       startDate='2017-01-01',
       endDate='2017-12-31',
-      metrics='estimatedMinutesWatched,views,likes,subscribersGained'
+      metrics='estimatedMinutesWatched,views,likes,subscribersGained',
       dimensions='day',
       sort='day'
   )


### PR DESCRIPTION
Very simple fix: missing a comma in code sample (function(x=1 y=2) -> function(x=1, y=2))