### PR TITLE
Resolve recursive folder creation error in nodejs-quickstart.js

### DIFF
--- a/javascript/nodejs-quickstart.js
+++ b/javascript/nodejs-quickstart.js
@@ -83,7 +83,7 @@ function getNewToken(oauth2Client, callback) {
  */
 function storeToken(token) {
   try {
-    fs.mkdirSync(TOKEN_DIR);
+    fs.mkdirSync(TOKEN_DIR, { recursive: true });
   } catch (err) {
     if (err.code != 'EEXIST') {
       throw err;


### PR DESCRIPTION
Refer to [issue 434](https://github.com/youtube/api-samples/issues/434)

[Here's](https://stackoverflow.com/questions/28498296/enoent-no-such-file-or-directory-on-fs-mkdirsync) a Stackoverflow thread on it.