### PR TITLE
Add comma to fix SyntaxError

### DIFF
--- a/python/yt_analytics_v2.py
+++ b/python/yt_analytics_v2.py
@@ -35,7 +35,7 @@ if __name__ == '__main__':
       ids='channel==MINE',
       startDate='2017-01-01',
       endDate='2017-12-31',
-      metrics='estimatedMinutesWatched,views,likes,subscribersGained'
+      metrics='estimatedMinutesWatched,views,likes,subscribersGained',
       dimensions='day',
       sort='day'
   )


### PR DESCRIPTION
The sample script produces a `SyntaxError` due to a missing comma. This PR adds a comma after the `metrics` argument so the script can run successfully.