### PR TITLE
Update search_by_keyword.go

### DIFF
--- a/go/search_by_keyword.go
+++ b/go/search_by_keyword.go
@@ -30,7 +30,7 @@ func main() {
 	}
 
 	// Make the API call to YouTube.
-	call := service.Search.List("id,snippet").
+	call := service.Search.List([]string{"id,snippet"}).
 		Q(*query).
 		MaxResults(*maxResults)
 	response, err := call.Do()


### PR DESCRIPTION
Fixed error in the service.Search.List parameter as []string value is required. 

The code returns the below error:

```shell
./search_by_keywords.go:33:30: cannot use "id,snippet" (untyped string constant) as []string value in argument to service.Search.List
```

I have update the parameter to a `[]string{"id, snippet"}` which has fixed the error.