### PR TITLE
fix: wrapped string into slice to pass into List func

### DIFF
--- a/go/quickstart.go
+++ b/go/quickstart.go
@@ -105,7 +105,7 @@ func handleError(err error, message string) {
 }
 
 func channelsListByUsername(service *youtube.Service, part string, forUsername string) {
-  call := service.Channels.List(part)
+  call := service.Channels.List([]string{part})
   call = call.ForUsername(forUsername)
   response, err := call.Do()
   handleError(err, "")


### PR DESCRIPTION
based on this [example](https://developers.google.com/youtube/v3/quickstart/go#step_3_set_up_the_sample), there is [an error](https://github.com/youtube/api-samples/blob/07263305b59a7c3275bc7e925f9ce6cabf774022/go/quickstart.go#L108), but it expects slice than simple string

```go
func (r *ChannelsService) List(part []string) *ChannelsListCall {
	c := &ChannelsListCall{s: r.s, urlParams_: make(gensupport.URLParams)}
	c.urlParams_.SetMulti("part", append([]string{}, part...))
	return c
}
```

func accepts slice of string, but the example wants to pass just an string.

[channelsListByUsername](https://go.dev/play/p/Qz5CnbyhZAm)

CLA i have already created