### PR TITLE
upload_video.py : httplib to http.client

### DIFF
--- a/python/upload_video.py
+++ b/python/upload_video.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 import argparse
-import httplib
+import http.client as httplib
 import httplib2
 import os
 import random


### PR DESCRIPTION
The httplib module has been renamed to http.client in Python 3.  See:  [Python 20.7. httplib](https://docs.python.org/2/library/httplib.html#:~:text=The%20httplib%20module%20has%20been%20renamed%20to%20http.client%20in%20Python%203.).